### PR TITLE
Avoid invalid memory access to already deleted C++ object

### DIFF
--- a/spec/inliner_spec.rb
+++ b/spec/inliner_spec.rb
@@ -258,20 +258,15 @@ EOC
       module Foo
         inline :cpp do |builder|
           builder.raw %{
-            #include <iostream>
-            #include <string>
-
-            using namespace std;
-
             class Greeter
             {
               public:
                 Greeter();
-                string say_hello();
+                const char *say_hello();
             };
 
             Greeter::Greeter () { };
-            string Greeter::say_hello ()
+            const char *Greeter::say_hello ()
             {
                 return "Hello foos!";
             };
@@ -281,7 +276,7 @@ EOC
             const char* say_hello () {
               Greeter greeter;
 
-              return greeter.say_hello().c_str();
+              return greeter.say_hello();
             }
           }, return: :string
         end


### PR DESCRIPTION
Using a simple C++ class should be sufficient to do a C++ test and avoids already freed memory.

Valgrind output was:

```
==11360== Invalid read of size 1
==11360==    at 0x4C2BFA2: strlen (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11360==    by 0x4F5D56A: rb_str_new2 (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4F5D6A4: rb_tainted_str_new2 (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0xAA282BD: rbffi_NativeValue_ToRuby (in /home/likewise-open/COMCARD-NT/kanis/.rvm/gems/ruby-1.9.3-p194/gems/ffi-1.1.5/lib/ffi_c.so)
==11360==    by 0xAA294DC: rbffi_CallFunction (in /home/likewise-open/COMCARD-NT/kanis/.rvm/gems/ruby-1.9.3-p194/gems/ffi-1.1.5/lib/ffi_c.so)
==11360==    by 0xAA29FE5: custom_trampoline (in /home/likewise-open/COMCARD-NT/kanis/.rvm/gems/ruby-1.9.3-p194/gems/ffi-1.1.5/lib/ffi_c.so)
==11360==    by 0x4FB4BAB: call_cfunc (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4FC21A0: vm_call0 (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4FC2538: rb_vm_call (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4E98087: rb_method_call (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4E98AC4: bmcall (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4FB65DD: vm_yield_with_cfunc (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==  Address 0x9b6cdd8 is 24 bytes inside a block of size 36 free'd
==11360==    at 0x4C2A4BC: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11360==    by 0xC0F2C12: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.16)
==11360==    by 0xB64AB0D: say_hello (in /tmp/.ffi-inliner-2087191961/3239782cb849b711fd16b592579c5e4b82dd471a.so)
==11360==    by 0xAA3502B: ffi_call_unix64 (in /home/likewise-open/COMCARD-NT/kanis/.rvm/gems/ruby-1.9.3-p194/gems/ffi-1.1.5/lib/ffi_c.so)
==11360==    by 0xAA34AD6: ffi_call (ffi64.c:486)
==11360==    by 0xAA29480: rbffi_CallFunction (in /home/likewise-open/COMCARD-NT/kanis/.rvm/gems/ruby-1.9.3-p194/gems/ffi-1.1.5/lib/ffi_c.so)
==11360==    by 0xAA29FE5: custom_trampoline (in /home/likewise-open/COMCARD-NT/kanis/.rvm/gems/ruby-1.9.3-p194/gems/ffi-1.1.5/lib/ffi_c.so)
==11360==    by 0x4FB4BAB: call_cfunc (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4FC21A0: vm_call0 (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4FC2538: rb_vm_call (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4E98087: rb_method_call (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
==11360==    by 0x4E98AC4: bmcall (in /home/likewise-open/COMCARD-NT/kanis/.rvm/rubies/ruby-1.9.3-p194/lib/libruby.so.1.9.1)
```
